### PR TITLE
Enhance lineage graph with intermediate node handling

### DIFF
--- a/src/sql2lineage/__init__.py
+++ b/src/sql2lineage/__init__.py
@@ -1,4 +1,4 @@
 """sql2lineage package."""
 
 __app_name__ = "sql2lineage"
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/src/sql2lineage/model.py
+++ b/src/sql2lineage/model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-member
 
 import re
-from typing import Dict, Optional, Set
+from typing import Dict, Literal, Optional, Set
 
 from pydantic import (
     BaseModel,
@@ -23,6 +23,10 @@ class SourceTable(BaseModel):
     target: str = Field(..., description="The output table of the source.")
     source: str = Field(..., description="The source table of the expression.")
     alias: Optional[str] = Field(None, description="The alias of the source table.")
+    type: Literal["TABLE", "SUBQUERY", "CTE", "UNNEST"] = Field(
+        "TABLE",
+        description="The type of the source table (e.g., 'TABLE', 'SUBQUERY', 'CTE').",
+    )
 
     def __hash__(self):
         return hash((self.target, self.source, self.alias))
@@ -112,6 +116,7 @@ class ParsedExpression(BaseModel):
                         "target": src.target,
                         "source": src.source,
                         "alias": src.alias,
+                        "table_type": src.type,
                     }
                     for src in self.tables
                 ],
@@ -386,6 +391,3 @@ class LineageResult(BaseModel):
     source: str = Field(..., description="The source of the lineage.")
     target: str = Field(..., description="The target of the lineage.")
     type: Optional[str] = Field(None, description="The type of the (e.g., 'COLUMN').")
-    action: Optional[str] = Field(
-        None, description="The action performed on the column (e.g., 'COPY')."
-    )

--- a/src/sql2lineage/parser.py
+++ b/src/sql2lineage/parser.py
@@ -145,6 +145,7 @@ class SQLLineageParser:  # noqa: D101 # pylint: disable=missing-class-docstring
                         target=cte_target,
                         source=source.source,
                         alias=source.alias,
+                        type="CTE",
                     )
                 )
 
@@ -179,6 +180,7 @@ class SQLLineageParser:  # noqa: D101 # pylint: disable=missing-class-docstring
                                 target=parsed_expression.target,
                                 source=table.source,
                                 alias=table.alias,
+                                type="SUBQUERY",
                             )
                         )
 
@@ -193,6 +195,7 @@ class SQLLineageParser:  # noqa: D101 # pylint: disable=missing-class-docstring
                         target=parsed_expression.target,
                         source=source_table,
                         alias=join.this.alias_or_name,
+                        type="UNNEST",
                     ),
                 )
 
@@ -203,6 +206,7 @@ class SQLLineageParser:  # noqa: D101 # pylint: disable=missing-class-docstring
                         target=parsed_expression.target,
                         source=source_table,
                         alias=join.alias_or_name,
+                        type="TABLE",
                     ),
                 )
 
@@ -223,6 +227,7 @@ class SQLLineageParser:  # noqa: D101 # pylint: disable=missing-class-docstring
                     target=parsed_expression.target,
                     source=source_table,
                     alias=source.alias_or_name,
+                    type="TABLE",
                 ),
             )
         elif isinstance(source, Subquery):
@@ -237,6 +242,7 @@ class SQLLineageParser:  # noqa: D101 # pylint: disable=missing-class-docstring
                         target=parsed_expression.target,
                         source=subquery_source.source,
                         alias=subquery_source.alias,
+                        type="SUBQUERY",
                     )
                 )
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,10 @@
 """Test the graph module."""
 
+from pathlib import Path
+
 import pytest
 
-from sql2lineage.graph import LineageGraph
+from sql2lineage.graph import IntermediateNodeStore, LineageGraph
 from sql2lineage.model import (
     ColumnLineage,
     LineageResult,
@@ -167,11 +169,13 @@ class TestLinageGraph:
                 "COLUMN",
                 [
                     [
-                        LineageResult(
-                            source="raw.orders.order_id",
-                            target="orders_with_tax.order_id",
-                            type="COLUMN",
-                            action="COPY",
+                        LineageResult.model_validate(
+                            {
+                                "source": "raw.orders.order_id",
+                                "target": "orders_with_tax.order_id",
+                                "type": "COLUMN",
+                                "action": "COPY",
+                            }
                         )
                     ]
                 ],
@@ -182,23 +186,29 @@ class TestLinageGraph:
                 "TABLE",
                 [
                     [
-                        LineageResult(
-                            source="raw.orders",
-                            target="orders_with_tax",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "raw.orders",
+                                "target": "orders_with_tax",
+                                "type": "TABLE",
+                                "table_type": "CTE",
+                            }
                         ),
-                        LineageResult(
-                            source="orders_with_tax",
-                            target="filtered_orders",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "orders_with_tax",
+                                "target": "filtered_orders",
+                                "type": "TABLE",
+                                "table_type": "CTE",
+                            }
                         ),
-                        LineageResult(
-                            source="filtered_orders",
-                            target="big_orders",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "filtered_orders",
+                                "target": "big_orders",
+                                "type": "TABLE",
+                                "table_type": "TABLE",
+                            }
                         ),
                     ]
                 ],
@@ -218,23 +228,29 @@ class TestLinageGraph:
                 "COLUMN",
                 [
                     [
-                        LineageResult(
-                            source="raw.orders.order_id",
-                            target="orders_with_tax.order_id",
-                            type="COLUMN",
-                            action="COPY",
+                        LineageResult.model_validate(
+                            {
+                                "source": "raw.orders.order_id",
+                                "target": "orders_with_tax.order_id",
+                                "type": "COLUMN",
+                                "action": "COPY",
+                            }
                         ),
-                        LineageResult(
-                            source="orders_with_tax.order_id",
-                            target="filtered_orders.order_id",
-                            type="COLUMN",
-                            action="COPY",
+                        LineageResult.model_validate(
+                            {
+                                "source": "orders_with_tax.order_id",
+                                "target": "filtered_orders.order_id",
+                                "type": "COLUMN",
+                                "action": "COPY",
+                            }
                         ),
-                        LineageResult(
-                            source="filtered_orders.order_id",
-                            target="big_orders.order_id",
-                            type="COLUMN",
-                            action="COPY",
+                        LineageResult.model_validate(
+                            {
+                                "source": "filtered_orders.order_id",
+                                "target": "big_orders.order_id",
+                                "type": "COLUMN",
+                                "action": "COPY",
+                            }
                         ),
                     ]
                 ],
@@ -245,23 +261,29 @@ class TestLinageGraph:
                 "TABLE",
                 [
                     [
-                        LineageResult(
-                            source="raw.orders",
-                            target="orders_with_tax",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "raw.orders",
+                                "target": "orders_with_tax",
+                                "type": "TABLE",
+                                "table_type": "CTE",
+                            }
                         ),
-                        LineageResult(
-                            source="orders_with_tax",
-                            target="filtered_orders",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "orders_with_tax",
+                                "target": "filtered_orders",
+                                "type": "TABLE",
+                                "table_type": "CTE",
+                            }
                         ),
-                        LineageResult(
-                            source="filtered_orders",
-                            target="big_orders",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "filtered_orders",
+                                "target": "big_orders",
+                                "type": "TABLE",
+                                "table_type": "TABLE",
+                            }
                         ),
                     ]
                 ],
@@ -281,25 +303,31 @@ class TestLinageGraph:
                 "COLUMN",
                 [
                     [
-                        LineageResult(
-                            source="raw.orders.order_id",
-                            target="orders_with_tax.order_id",
-                            type="COLUMN",
-                            action="COPY",
+                        LineageResult.model_validate(
+                            {
+                                "source": "raw.orders.order_id",
+                                "target": "orders_with_tax.order_id",
+                                "type": "COLUMN",
+                                "action": "COPY",
+                            }
                         ),
-                        LineageResult(
-                            source="orders_with_tax.order_id",
-                            target="filtered_orders.order_id",
-                            type="COLUMN",
-                            action="COPY",
+                        LineageResult.model_validate(
+                            {
+                                "source": "orders_with_tax.order_id",
+                                "target": "filtered_orders.order_id",
+                                "type": "COLUMN",
+                                "action": "COPY",
+                            }
                         ),
                     ],
                     [
-                        LineageResult(
-                            source="filtered_orders.order_id",
-                            target="big_orders.order_id",
-                            type="COLUMN",
-                            action="COPY",
+                        LineageResult.model_validate(
+                            {
+                                "source": "filtered_orders.order_id",
+                                "target": "big_orders.order_id",
+                                "type": "COLUMN",
+                                "action": "COPY",
+                            }
                         ),
                     ],
                 ],
@@ -310,25 +338,31 @@ class TestLinageGraph:
                 "TABLE",
                 [
                     [
-                        LineageResult(
-                            source="raw.orders",
-                            target="orders_with_tax",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "raw.orders",
+                                "target": "orders_with_tax",
+                                "type": "TABLE",
+                                "table_type": "CTE",
+                            }
                         ),
-                        LineageResult(
-                            source="orders_with_tax",
-                            target="filtered_orders",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "orders_with_tax",
+                                "target": "filtered_orders",
+                                "type": "TABLE",
+                                "table_type": "CTE",
+                            }
                         ),
                     ],
                     [
-                        LineageResult(
-                            source="filtered_orders",
-                            target="big_orders",
-                            type="TABLE",
-                            action=None,
+                        LineageResult.model_validate(
+                            {
+                                "source": "filtered_orders",
+                                "target": "big_orders",
+                                "type": "TABLE",
+                                "table_type": "TABLE",
+                            }
                         ),
                     ],
                 ],
@@ -339,3 +373,71 @@ class TestLinageGraph:
     def test_get_node_neighbours(self, graph, node, node_type, expected):
         """Test get node neighbours."""
         assert graph.get_node_neighbours(node, node_type) == expected
+
+    def test_get_node_lineage_physical(self, graph):
+        """Test get node lineage physical."""
+        parser = SQLLineageParser(dialect="bigquery")
+
+        with Path("tests/sql/example.sql").open("r", encoding="utf-8") as src:
+            parsed_result = parser.extract_lineage(src.read())
+
+        graph = LineageGraph()
+        graph.from_parsed(parsed_result.expressions)
+
+        actual = graph.get_node_neighbours(
+            node="big_orders", node_type="TABLE", physical_nodes_only=True
+        )
+        assert actual == [
+            [
+                LineageResult.model_validate(
+                    {
+                        "source": "raw.orders",
+                        "target": "big_orders",
+                        "type": "TABLE",
+                        "table_type": "TABLE",
+                    }
+                )
+            ]
+        ]
+
+
+class TestIntermediateNodeStore:
+    """Test IntermediateNodeStore."""
+
+    def test_setitem_and_getitem(self):
+        """Test that using __setitem__ and __getitem__ works correctly."""
+        store = IntermediateNodeStore()
+        store["node1"] = "value1"
+        store["node2"] = "value2"
+        assert store["node1"] == "value1"
+        assert store["node2"] == "value2"
+
+    def test_getitem_keyerror(self):
+        """Test that __getitem__ raises a KeyError for missing keys."""
+        store = IntermediateNodeStore()
+        store["node1"] = "value1"
+        with pytest.raises(KeyError):
+            _ = store["non_existing_node"]
+
+    def test_contains(self):
+        """Test that __contains__ correctly identifies existing and non-existing keys."""
+        store = IntermediateNodeStore()
+        store["node1"] = "value1"
+        store.add(("node2", "value2"))
+        assert "node1" in store
+        assert "node2" in store
+        assert "non_existing" not in store
+
+    def test_add_method(self):
+        """Test that the add() method correctly adds nodes."""
+        store = IntermediateNodeStore()
+        store.add(("node3", "value3"))
+        assert store["node3"] == "value3"
+
+    def test_duplicate_keys(self):
+        """Test that duplicate keys return the first inserted value when using __getitem__."""
+        store = IntermediateNodeStore()
+        store["node_dup"] = "first_value"
+        store.add(("node_dup", "second_value"))
+        # __getitem__ should return the value from the first occurrence.
+        assert store["node_dup"] == "first_value"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -34,12 +34,14 @@ class TestSourceTable:
             source="source_table",
             target="target_table",
             alias="alias_name",
+            type="TABLE",
         )
 
         assert source_table.model_dump() == {
             "source": "source_table",
             "target": "target_table",
             "alias": "alias_name",
+            "type": "TABLE",
         }
 
 
@@ -63,6 +65,7 @@ class TestParsedExpression:
                 source="source_table",
                 target="target_table",
                 alias="alias_name",
+                type="TABLE",
             )
         )
 
@@ -81,6 +84,7 @@ class TestParsedExpression:
                     "source": "source_table",
                     "target": "target_table",
                     "alias": "alias_name",
+                    "table_type": "TABLE",
                 }
             ],
             "subqueries": {},
@@ -108,6 +112,7 @@ class TestParsedResult:
                 source="source_table",
                 target="target_table",
                 alias="alias_name",
+                type="TABLE",
             )
         )
 
@@ -131,6 +136,7 @@ class TestParsedResult:
                             "source": "source_table",
                             "target": "target_table",
                             "alias": "alias_name",
+                            "table_type": "TABLE",
                         }
                     ],
                     "subqueries": {},

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -78,16 +78,19 @@ class TestParser:
                             "target": "big_orders",
                             "source": "filtered_orders",
                             "alias": "filtered_orders",
+                            "table_type": "TABLE",
                         },
                         {
                             "target": "filtered_orders",
                             "source": "orders_with_tax",
                             "alias": "orders_with_tax",
+                            "table_type": "CTE",
                         },
                         {
                             "target": "orders_with_tax",
                             "source": "raw.orders",
                             "alias": "orders",
+                            "table_type": "CTE",
                         },
                     ],
                     "subqueries": {},
@@ -124,8 +127,14 @@ class TestParser:
                             "target": "join_example",
                             "source": "raw.user_details",
                             "alias": "user_details",
+                            "table_type": "SUBQUERY",
                         },
-                        {"target": "join_example", "source": "raw.users", "alias": "a"},
+                        {
+                            "target": "join_example",
+                            "source": "raw.users",
+                            "alias": "a",
+                            "table_type": "TABLE",
+                        },
                     ],
                     "subqueries": {
                         "b": {
@@ -149,6 +158,7 @@ class TestParser:
                                     "target": "",
                                     "source": "raw.user_details",
                                     "alias": "user_details",
+                                    "table_type": "TABLE",
                                 }
                             ],
                             "subqueries": {},
@@ -189,8 +199,14 @@ class TestParser:
                             "target": "join_example",
                             "source": "raw.user_details",
                             "alias": "b",
+                            "table_type": "TABLE",
                         },
-                        {"target": "join_example", "source": "raw.users", "alias": "a"},
+                        {
+                            "target": "join_example",
+                            "source": "raw.users",
+                            "alias": "a",
+                            "table_type": "TABLE",
+                        },
                     ],
                     "subqueries": {},
                     "expression": "CREATE TABLE join_example AS\nSELECT\n  a.id AS id,\n  a.name,\n  b.age AS age\nFROM raw.users AS a\nJOIN raw.user_details AS b\n  ON a.id = b.id\nWHERE\n  NOT a.name IS NULL AND b.age > 18",
@@ -250,11 +266,13 @@ class TestParser:
                             "target": "unnest_example",
                             "source": "raw_orders",
                             "alias": "",
+                            "table_type": "UNNEST",
                         },
                         {
                             "target": "unnest_example",
                             "source": "raw_orders",
                             "alias": "src",
+                            "table_type": "TABLE",
                         },
                     ],
                     "subqueries": {},
@@ -285,6 +303,7 @@ class TestParser:
                             "target": "from_subquery",
                             "source": "raw.user_details",
                             "alias": "user_details",
+                            "table_type": "SUBQUERY",
                         }
                     ],
                     "subqueries": {
@@ -309,6 +328,7 @@ class TestParser:
                                     "target": "",
                                     "source": "raw.user_details",
                                     "alias": "user_details",
+                                    "table_type": "TABLE",
                                 }
                             ],
                             "subqueries": {},
@@ -377,11 +397,13 @@ class TestParser:
                             "target": "cte_with_subquery",
                             "source": "test_table",
                             "alias": "test_table",
+                            "table_type": "CTE",
                         },
                         {
                             "target": "expr000",
                             "source": "cte_with_subquery",
                             "alias": "cte_with_subquery",
+                            "table_type": "TABLE",
                         },
                     ],
                     "subqueries": {},

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [[package]]
@@ -261,7 +262,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -908,7 +909,6 @@ wheels = [
 
 [[package]]
 name = "sql2lineage"
-version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR allows the neighbourhood to skip intermediate nodes - i.e. CTE's, unnests, and subqueries.

This is achieved by calling: 

```python
graph.get_node_neighbours(
    node="orders_with_tax", node_type="TABLE", physical_nodes_only=True
)
```

The purpose is to allow the graph to be incorporated into systems which reference the objects (views, tables, etc) within a data warehouse.