### PR TITLE
Fix handling of `select *`

### DIFF
--- a/src/sql2lineage/__init__.py
+++ b/src/sql2lineage/__init__.py
@@ -1,4 +1,4 @@
 """sql2lineage package."""
 
 __app_name__ = "sql2lineage"
-__version__ = "0.5.0"
+__version__ = "0.5.1-rc.1"


### PR DESCRIPTION
Bump the version to 0.5.1-rc.1 and improve handling of expressions, particularly for the `Star` expression in the model, ensuring correct identification of source tables.